### PR TITLE
Bugfix unicode compatibility

### DIFF
--- a/codes/run.py
+++ b/codes/run.py
@@ -124,7 +124,7 @@ def read_triple(file_path, entity2id, relation2id):
     triples = []
     with open(file_path) as fin:
         for line in fin:
-             h, r, t = map(lambda x: x.strip(), unicodedata.normalize('NFKC', line).split('\t'))
+            h, r, t = map(lambda x: x.strip(), unicodedata.normalize('NFKC', line).split('\t'))
             triples.append((entity2id[h], relation2id[r], entity2id[t]))
     return triples
 

--- a/codes/run.py
+++ b/codes/run.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 import random
-import unicodedata
 
 import numpy as np
 import torch
@@ -124,7 +123,10 @@ def read_triple(file_path, entity2id, relation2id):
     triples = []
     with open(file_path) as fin:
         for line in fin:
-            h, r, t = map(lambda x: x.strip(), unicodedata.normalize('NFKC', line).split('\t'))
+            # The entity/relation dict have the element names at the end, when loading them
+            # the entire line is stripped, removing any trailing spaces. As such, we need
+            # to strip each element individually here as well.
+            h, r, t = map(str.strip, line.split('\t'))
             triples.append((entity2id[h], relation2id[r], entity2id[t]))
     return triples
 
@@ -180,13 +182,13 @@ def main(args):
     with open(os.path.join(args.data_path, 'entities.dict')) as fin:
         entity2id = dict()
         for line in fin:
-            eid, entity = map(lambda x: x.strip(), unicodedata.normalize('NFKC', line).split('\t'))
+            eid, entity = line.strip().split('\t')
             entity2id[entity] = int(eid)
 
     with open(os.path.join(args.data_path, 'relations.dict')) as fin:
         relation2id = dict()
         for line in fin:
-            rid, relation = map(lambda x: x.strip(), unicodedata.normalize('NFKC', line).split('\t'))
+            rid, relation = line.strip().split('\t')
             relation2id[relation] = int(rid)
     
     # Read regions for Countries S* datasets

--- a/codes/run.py
+++ b/codes/run.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import random
+import unicodedata
 
 import numpy as np
 import torch
@@ -123,7 +124,7 @@ def read_triple(file_path, entity2id, relation2id):
     triples = []
     with open(file_path) as fin:
         for line in fin:
-            h, r, t = line.strip().split('\t')
+             h, r, t = map(lambda x: x.strip(), unicodedata.normalize('NFKC', line).split('\t'))
             triples.append((entity2id[h], relation2id[r], entity2id[t]))
     return triples
 
@@ -160,12 +161,12 @@ def log_metrics(mode, step, metrics):
         
 def main(args):
     if (not args.do_train) and (not args.do_valid) and (not args.do_test):
-        raise ValueError('one of train/val/test mode must be choosed.')
+        raise ValueError('one of train/val/test mode must be chosen.')
     
     if args.init_checkpoint:
         override_config(args)
     elif args.data_path is None:
-        raise ValueError('one of init_checkpoint/data_path must be choosed.')
+        raise ValueError('one of init_checkpoint/data_path must be chosen.')
 
     if args.do_train and args.save_path is None:
         raise ValueError('Where do you want to save your trained model?')
@@ -179,13 +180,13 @@ def main(args):
     with open(os.path.join(args.data_path, 'entities.dict')) as fin:
         entity2id = dict()
         for line in fin:
-            eid, entity = line.strip().split('\t')
+            eid, entity = map(lambda x: x.strip(), unicodedata.normalize('NFKC', line).split('\t'))
             entity2id[entity] = int(eid)
 
     with open(os.path.join(args.data_path, 'relations.dict')) as fin:
         relation2id = dict()
         for line in fin:
-            rid, relation = line.strip().split('\t')
+            rid, relation = map(lambda x: x.strip(), unicodedata.normalize('NFKC', line).split('\t'))
             relation2id[relation] = int(rid)
     
     # Read regions for Countries S* datasets


### PR DESCRIPTION
Hi,

When operating on my data set I was getting the following error:

```
> Traceback (most recent call last):
>   File "codes/run.py", line 361, in <module>
>     main(parse_args())
>   File "codes/run.py", line 211, in main
>     train_triples = read_triple(os.path.join(args.data_path, 'train.txt'), entity2id, relation2id)
>   File "codes/run.py", line 127, in read_triple
>     triples.append((entity2id[h], relation2id[r], entity2id[t]))
> KeyError: 'Găgăuzia\xa0'
```

To fix the issue, I added calls to `unicodedata.normalize()` before loading triples to normalize such weird characters (non-breaking spaces). I also fixed two minor grammatical mistakes in error messages.